### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server that provides real-time access to Hong Kong's KMB (九龍巴士) and Long Win Bus (龍運巴士) route information and arrival times. This server enables Language Models to query Hong Kong bus service information to answer user questions about bus routes, stops, and estimated arrival times.
 
+<a href="https://glama.ai/mcp/servers/@kennyckk/mcp_hkbus">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kennyckk/mcp_hkbus/badge" alt="KMB Bus Server MCP server" />
+</a>
+
 ## Features
 
 - Real-time bus arrival information (ETA)


### PR DESCRIPTION
This PR adds a badge for the [KMB Bus MCP Server](https://glama.ai/mcp/servers/@kennyckk/mcp_hkbus) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kennyckk/mcp_hkbus">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kennyckk/mcp_hkbus/badge" alt="KMB Bus Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.